### PR TITLE
Fix the helm registry plugin install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
 FROM ubuntu:latest
 MAINTAINER Michael Venezia <mvenezia@gmail.com>
 
+ENV HELM_HOME=/etc/helm
 ENV HELM_RELEASE=v2.5.0
-ENV APP_REGISTRY_PLUGIN_RELEASE=v0.4.1
+ENV APP_REGISTRY_PLUGIN_RELEASE=v0.5.0
+ENV APP_REGISTRY_PLUGIN_URL=https://github.com/app-registry/appr/releases/download/${APP_REGISTRY_PLUGIN_RELEASE}/appr-linux-x64
+ENV APP_REGISTRY_PLUGIN_YAML_URL=https://raw.githubusercontent.com/app-registry/appr/${APP_REGISTRY_PLUGIN_RELEASE}/appr/commands/plugins/helm/plugin.yaml
+ENV APP_REGISTRY_PLUGIN_SCRIPT_URL=https://raw.githubusercontent.com/app-registry/appr/${APP_REGISTRY_PLUGIN_RELEASE}/appr/commands/plugins/helm/cnr.sh
 
-RUN mkdir -p ~/.helm/plugins
+RUN mkdir -p /etc/helm/plugins/appr && ln -s /etc/helm ~/.helm
 
-RUN apt-get update && apt-get install -y curl openssl git gettext-base && \
-    curl -k -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_RELEASE}-linux-amd64.tar.gz | tar -zxv linux-amd64/helm && \
-    mv linux-amd64/helm /usr/bin/ && rm -rf linux-amd64 && \
-    cd ~/.helm/plugins && \
-    curl -k -L https://github.com/app-registry/appr-helm-plugin/releases/download/${APP_REGISTRY_PLUGIN_RELEASE}/registry-helm-plugin.tar.gz | tar -zxv && \
+RUN apt-get update && apt-get install -y wget openssl git gettext-base
+RUN wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_RELEASE}-linux-amd64.tar.gz -O - | tar -zxv linux-amd64/helm && \
+    mv linux-amd64/helm /usr/bin/ && rm -rf linux-amd64
+WORKDIR /etc/helm/plugins/appr
+RUN wget ${APP_REGISTRY_PLUGIN_URL} -O appr && \
+    wget ${APP_REGISTRY_PLUGIN_YAML_URL} -O plugin.yaml && \
+    wget ${APP_REGISTRY_PLUGIN_SCRIPT_URL} -O appr.sh && \
+    chmod +x appr appr.sh
+WORKDIR /
+RUN helm plugin list && \
     helm registry list quay.io


### PR DESCRIPTION
The upstream github repo we were using was archived after the cli
repo was merged with the server repo. This uses the new repo and new
plugin app name.